### PR TITLE
Update README.md to point to the latest LICENSE under the DxCapsViewer repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Documentation is available on the [GitHub wiki](https://github.com/microsoft/DxC
 
 ## Notices
 
-All content and source code for this package are subject to the terms of the [MIT License](http://opensource.org/licenses/MIT).
+All content and source code for this package are subject to the terms of the [MIT License](LICENSE).
 
 For the latest version of this tool, bug reports, etc. please visit the project site on [GitHub](https://github.com/microsoft/DxCapsViewer).
 


### PR DESCRIPTION
Updated README.md file to point to the MIT License under the [DxCapsViewer](https://github.com/microsoft/DxCapsViewer) repo instead of `https://opensource.org/licenses/MIT` (as it provides more of the generalized view.)

Copyright (c) 2002-2022 Microsoft Corp