### PR TITLE
Make DXCapsViewer VCPKG profiles build out of the box

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "builtin-baseline": "a9eee3b18df395dbb8be71a31bd78ea441056e42",
   "dependencies": [
     "directx-headers",
     "directx12-agility"


### PR DESCRIPTION
VS built VCPKG runs only in manifest mode and requires a Baseline SHA.

The Json also needs to be located at the root directory, having it inside the build directory meant that visual studio never finished cache generation as it never automatically installed the vcpkg dependencies.