### PR TITLE
Update GHA that use VCPKG to support workflow trigger

### DIFF
--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -14,6 +14,7 @@ on:
       - '*.md'
       - LICENSE
       - build/*
+  workflow_dispatch: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
This allows manual starting this action via the website since it references repository variables to select which VCPKG baseline to use.